### PR TITLE
Using String instead of NSString to avoid casting.

### DIFF
--- a/SetupXcodeDerivedDataRamDisk/main.swift
+++ b/SetupXcodeDerivedDataRamDisk/main.swift
@@ -182,7 +182,7 @@ func runTask(launchPath: String,
     task.launch()
     let data = pipe.fileHandleForReading.readDataToEndOfFile()
 
-    return NSString(data: data, encoding: String.Encoding.utf8.rawValue) as! String;
+    return String(data: data, encoding: String.Encoding.utf8)!
 }
 
 print("Setting up RAM disk for Xcode.\n")


### PR DESCRIPTION
Hi, I found a warning when I open the project in Xcode 8.3.1. So I just create this PR to do a simple fix. Sorry I didn't ask you in advance, please feel free to just close it if you don't want it.
The warning is:
`SetupXcodeDerivedDataRamDisk/main.swift:185:74: Forced cast from 'NSString?' to 'String' only unwraps and bridges; did you mean to use '!' with 'as'?`
