### PR TITLE
Added support for ensuring that the DerivedData directory exists

### DIFF
--- a/SetupXcodeDerivedDataRamDisk/main.swift
+++ b/SetupXcodeDerivedDataRamDisk/main.swift
@@ -157,8 +157,15 @@ func makeFilesystemOn(disk: String)
     mountRamDisk(drive: drive)
 }
 
+func ensureDerivedData() {
+    let output = runTask(launchPath: "/bin/mkdir",
+                         arguments: ["-p", derivedDataPath])
+    print(output)
+}
+
 func mountRamDisk(drive: String)
 {
+    ensureDerivedData()
     let output = runTask(launchPath: "/usr/sbin/diskutil",
                          arguments: ["mount", "-mountPoint", derivedDataPath, drive])
     print(output)

--- a/SetupXcodeDerivedDataRamDisk/main.swift
+++ b/SetupXcodeDerivedDataRamDisk/main.swift
@@ -157,7 +157,8 @@ func makeFilesystemOn(disk: String)
     mountRamDisk(drive: drive)
 }
 
-func ensureDerivedData() {
+func ensureDerivedData()
+{
     let output = runTask(launchPath: "/bin/mkdir",
                          arguments: ["-p", derivedDataPath])
     print(output)


### PR DESCRIPTION
On brand new installs, before Xcode has been run, the directory ~/Library/Developer/Xcode/DerivedData might not exist.  This change calls mkdir to ensure that the path exists before attempting to mount the ramdisk.